### PR TITLE
Fix vec_sum() signedness

### DIFF
--- a/0_intro/exercises/vec_sum/src/lib.rs
+++ b/0_intro/exercises/vec_sum/src/lib.rs
@@ -1,4 +1,4 @@
-pub fn vec_sum(vec: Vec<i32>) -> usize {
+pub fn vec_sum(vec: Vec<i32>) -> i32 {
     todo!()
 }
 


### PR DESCRIPTION
`vec_sum()` should return a signed integer so that the following assertion is valid

```rust
assert_eq!(-3, vec![-1, -2])
```
